### PR TITLE
Get the sine example working again

### DIFF
--- a/libsoundio-sys/build.rs
+++ b/libsoundio-sys/build.rs
@@ -74,7 +74,7 @@ fn main() {
 	// If we're cross-compiling to Windows from a non-Windows platform...
 	if windows && !host.contains("windows") {
 		// Get the name of the C compiler.
-		let c_compiler = gcc::Config::new().cargo_metadata(false)
+		let c_compiler = gcc::Build::new().cargo_metadata(false)
 										   .get_compiler();
 		let exe = c_compiler.path();
 

--- a/libsoundio-sys/lib.rs
+++ b/libsoundio-sys/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate libc;
 
-use std::os::raw::{c_char, c_void, c_int, c_double};
+use std::os::raw::{c_char, c_void, c_int, c_double, c_float};
 
 // There is no c_bool, but you can use Rust's i8 or bool instead.
 // See https://github.com/rust-lang/rfcs/pull/954#issuecomment-169820630
@@ -487,6 +487,7 @@ pub struct SoundIoOutStream {
     // For JACK, this value is always equal to
     // SoundIoDevice::software_latency_current of the device.
     pub software_latency: c_double,
+    pub volume: c_float,
 
     // Defaults to NULL. Put whatever you want here.
     pub userdata: *mut c_void,


### PR DESCRIPTION
I want to record audio using rust on my Windows machine and soundio-rs was the first library that said it could, so I tried building it using stable-x86_64-pc-windows-msvc.

I had to change some things to get the sine example working here.