### PR TITLE
Fixed issue with latency piling up due to not looping through all available samples to read/write

### DIFF
--- a/examples/player/main.rs
+++ b/examples/player/main.rs
@@ -45,13 +45,12 @@ impl WavPlayer {
 				}
 			}
 
-			stream.end_write();
-
 			frames_left -= stream.frame_count();
-			if frames_left <= 0
-			{
+			if frames_left <= 0 {
 				break;
 			}
+
+			stream.end_write();
 		}
 		if self.finished != was_finished {
 	//		stream.wakeup();

--- a/examples/player/main.rs
+++ b/examples/player/main.rs
@@ -13,7 +13,6 @@ use std::env;
 // let (write_callback, wav_player) = WavPlayer::new();
 //
 // Internally they can use a mutex to communicate.
-
 struct WavPlayer {
 	reader: hound::WavReader<BufReader<File>>,
 	finished: bool,
@@ -21,29 +20,37 @@ struct WavPlayer {
 
 impl WavPlayer {
 	fn write_callback(&mut self, stream: &mut soundio::OutStreamWriter) {
-		let frame_count_max = stream.frame_count_max();
-		if let Err(e) = stream.begin_write(frame_count_max) {
-			println!("Error writing to stream: {}", e);
-			return;
-		}
-
-		// Hound's sample conversion is not as awesome as mine. This will fail on floating point types.
-		let mut s = self.reader.samples::<i32>();
-
+		let mut frames_left = stream.frame_count_max();
 		let was_finished = self.finished;
+		loop {
+			if let Err(e) = stream.begin_write(frames_left) {
+				println!("Error writing to stream: {}", e);
+				return;
+			}
+			// Hound's sample conversion is not as awesome as mine. This will fail on floating point types.
+			let mut s = self.reader.samples::<i32>();
 
-		for f in 0..stream.frame_count() {
-    		for c in 0..stream.channel_count() {
-				match s.next() {
-					Some(x) => {
-						stream.set_sample(c, f, x.unwrap()); 
-					},
-					None => {
-						stream.set_sample(c, f, 0);
-						self.finished = true;
+			for f in 0..stream.frame_count() {
+	    		for c in 0..stream.channel_count() {
+					match s.next() {
+						Some(x) => {
+							stream.set_sample(c, f, x.unwrap()*1000); 
+						},
+						None => {
+							stream.set_sample(c, f, 0);
+							self.finished = true;
+						}
 					}
+					
 				}
-				
+			}
+
+			stream.end_write();
+
+			frames_left -= stream.frame_count();
+			if frames_left <= 0
+			{
+				break;
 			}
 		}
 		if self.finished != was_finished {
@@ -75,7 +82,6 @@ fn play(filename: &str) -> Result<(), String> {
 	println!("Flushing events.");
 	ctx.flush_events();
 	println!("Flushed");
-
 
 	let channels = reader.spec().channels;
 	let sample_rate = reader.spec().sample_rate;

--- a/examples/recorder/main.rs
+++ b/examples/recorder/main.rs
@@ -31,13 +31,12 @@ impl WavRecorder {
 				}
 			}
 
-			stream.end_read();
-
 			frames_left -= stream.frame_count();
-			if frames_left <= 0
-			{
+			if frames_left <= 0 {
 				break;
 			}
+
+			stream.end_read();
 		}
 	}
 }

--- a/examples/sine/main.rs
+++ b/examples/sine/main.rs
@@ -27,13 +27,13 @@ impl SineWavePlayer {
 					self.phase += phase_step;
 				}
 			}
-			stream.end_write();
 
 			frames_left -= stream.frame_count();
-			if frames_left <= 0
-			{
+			if frames_left <= 0 {
 				break;
 			}
+
+			stream.end_write();
 		}
 	}
 }

--- a/src/instream.rs
+++ b/src/instream.rs
@@ -248,8 +248,7 @@ impl<'a> InStreamReader<'a> {
 				self.read_started = true;
 				self.frame_count = actual_frame_count as _;
 				// Return now if there's no frames to actually read.
-				if actual_frame_count <= 0
-				{
+				if actual_frame_count <= 0 {
 					return Ok(0);
 				}
 				let cc = self.channel_count();
@@ -276,7 +275,7 @@ impl<'a> InStreamReader<'a> {
 		if self.read_started {
 			unsafe {
 				match raw::soundio_instream_end_read(self.instream) {
-					0 => {},
+					0 => {self.read_started = false;},
 					x => println!("Error ending instream: {}", Error::from(x)),
 				}
 			}
@@ -396,7 +395,7 @@ impl<'a> InStreamReader<'a> {
 	// TODO: To acheive speed *and* safety I can use iterators. That will be in a future API.
 }
 
-/*impl<'a> Drop for InStreamReader<'a> {
+impl<'a> Drop for InStreamReader<'a> {
 	/// This will drop all of the frames from when you called `begin_read()`.
 	///
 	/// Errors are currently are just printed to the console and ignored.
@@ -414,7 +413,4 @@ impl<'a> InStreamReader<'a> {
 			}
 		}
 	}
-}*/
-
-
-
+}

--- a/src/outstream.rs
+++ b/src/outstream.rs
@@ -285,7 +285,6 @@ impl<'a> OutStreamWriter<'a> {
 	///   case this error code is returned.
 	///
 	pub fn begin_write(&mut self, frame_count: usize) -> Result<usize> {
-		assert!(!self.write_started, "begin_write() called twice!");
 		assert!(frame_count >= self.frame_count_min && frame_count <= self.frame_count_max, "frame_count out of range");
 
 		let mut areas: *mut raw::SoundIoChannelArea = ptr::null_mut();
@@ -295,12 +294,39 @@ impl<'a> OutStreamWriter<'a> {
 			0 => {
 				self.write_started = true;
 				self.frame_count = actual_frame_count as _;
+				// Return now if there's no frames to actually read.
+				if actual_frame_count <= 0
+				{
+					return Ok(0);
+				}
 				let cc = self.channel_count();
 				self.channel_areas = vec![raw::SoundIoChannelArea { ptr: ptr::null_mut(), step: 0 }; cc];
 				unsafe { self.channel_areas.copy_from_slice(slice::from_raw_parts::<raw::SoundIoChannelArea>(areas, cc)); }
 				Ok(actual_frame_count as _)
 			},
 			e => Err(e.into()),
+		}
+	}
+
+	/// Commits the write that you began with `begin_write()`.
+	///
+	/// Errors are currently are just printed to the console and ignored.
+	///
+	/// # Errors
+	///
+	/// * `Error::Streaming`
+	/// * `Error::Underflow` - an underflow caused this call to fail. You might
+	///   also get an `underflow_callback()`, and you might not get
+	///   this error code when an underflow occurs. Unlike `Error::Streaming`,
+	///   the outstream is still in a valid state and streaming can continue.
+	pub fn end_write(&mut self) {
+		if self.write_started {
+			unsafe {
+				match raw::soundio_outstream_end_write(self.outstream) {
+					0 => {},
+					x => println!("Error writing outstream: {}", Error::from(x)),
+				}
+			}
 		}
 	}
 	
@@ -418,30 +444,3 @@ impl<'a> OutStreamWriter<'a> {
 
 	// TODO: To acheive speed *and* safety I can use iterators. That will be in a future API.
 }
-
-impl<'a> Drop for OutStreamWriter<'a> {
-	/// Commits the write that you began with `begin_write()`.
-	///
-	/// Errors are currently are just printed to the console and ignored.
-	///
-	/// # Errors
-	///
-	/// * `Error::Streaming`
-	/// * `Error::Underflow` - an underflow caused this call to fail. You might
-	///   also get an `underflow_callback()`, and you might not get
-	///   this error code when an underflow occurs. Unlike `Error::Streaming`,
-	///   the outstream is still in a valid state and streaming can continue.
-	fn drop(&mut self) {
-		if self.write_started {
-			unsafe {
-				match raw::soundio_outstream_end_write(self.outstream) {
-					0 => {},
-					x => println!("Error writing outstream: {}", Error::from(x)),
-				}
-			}
-		}
-	}
-}
-
-
-

--- a/src/outstream.rs
+++ b/src/outstream.rs
@@ -445,7 +445,7 @@ impl<'a> OutStreamWriter<'a> {
 }
 
 impl<'a> Drop for OutStreamWriter<'a> {
-	/// This will drop all of the frames from when you called `begin_read()`.
+	/// This will drop all of the frames from when you called `begin_write()`.
 	///
 	/// Errors are currently are just printed to the console and ignored.
 	///


### PR DESCRIPTION
Hey,

It looks like the problem I talked of in issue #2 is related to that both reading and writing with soundio seems to happen in chunks. `begin_read` and `begin_write` can be called multiple times and they will return a value that is often less than `stream.frame_count_max`.

I tried to copy how it's done in the official [microphone example](https://github.com/andrewrk/libsoundio/blob/master/example/sio_microphone.c) of libsoundio. You can see that both in the read and write callback, they loop with begin_read/write until all frames have been read/written.

Right now, I seem to have fixed my issue.. Though I couldn't get player example to work.